### PR TITLE
chore: increase the initializing duration setting for autoware

### DIFF
--- a/.webauto-ci.yaml
+++ b/.webauto-ci.yaml
@@ -23,7 +23,7 @@ simulations:
         architecture_type: awf/universe
         vehicle_model: sample_vehicle
         sensor_model: sample_sensor_kit
-        initialize_duration: "45"
+        initialize_duration: "90"
 
 release:
   components:


### PR DESCRIPTION
## Description

The `initialize_duration` shortage was found in BUS ODD WG due to increased autoware initialization time.
90 (seconds) is often used for `initialize_duration` internally in TIER IV, and it is working without any problems, so I will reflect this.

NOTE: `initialize_duration` in `.webauto-ci.yaml` is timeout setting for launching autoware in Autoware Evaluator. 
Strictly speaking, it is the timeout value for transitioning to WAITING_FOR_ENGAGE from the moment of launch.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
